### PR TITLE
Fix C VM events breaking disabled JIT builds

### DIFF
--- a/src/lj_jit.h
+++ b/src/lj_jit.h
@@ -8,7 +8,6 @@
 
 #include "lj_obj.h"
 #include "lj_ir.h"
-#include "vmevent.h"
 
 /* JIT engine flags. */
 #define JIT_F_ON		0x00000001
@@ -481,9 +480,6 @@ typedef struct jit_State {
   MCode *mcbot;		/* Bottom of current mcode area. */
   size_t szmcarea;	/* Size of current mcode area. */
   size_t szallmcarea;	/* Total size of all allocated mcode areas. */
-
-  luaJIT_vmevent_callback vmevent_cb; /* User set VM event callback. */
-  void *vmevent_data;   /* VM event callback data. */
 
   TValue errinfo;	/* Additional info element for trace errors. */
 

--- a/src/lj_obj.h
+++ b/src/lj_obj.h
@@ -12,6 +12,7 @@
 #include "lua.h"
 #include "lj_def.h"
 #include "lj_arch.h"
+#include "vmevent.h"
 
 /* -- Memory references (32 bit address space) ---------------------------- */
 
@@ -621,6 +622,9 @@ typedef struct global_State {
   MRef jit_base;	/* Current JIT code L->base or NULL. */
   MRef ctype_state;	/* Pointer to C type state. */
   GCRef gcroot[GCROOT_MAX];  /* GC roots. */
+
+  luaJIT_vmevent_callback vmevent_cb; /* User set VM event callback. */
+  void *vmevent_data;                 /* VM event callback data. */
 } global_State;
 
 #define mainthread(g)	(&gcref(g->mainthref)->th)

--- a/src/lj_vmevent.c
+++ b/src/lj_vmevent.c
@@ -60,19 +60,19 @@ void lj_vmevent_call(lua_State *L, ptrdiff_t argbase)
 LUA_API int luaJIT_vmevent_sethook(lua_State *L, luaJIT_vmevent_callback cb, void *data)
 {
   if (cb) {
-    L2J(L)->vmevent_cb = cb;
-    L2J(L)->vmevent_data = data;
+    G(L)->vmevent_cb = cb;
+    G(L)->vmevent_data = data;
   } else {
     lua_assert(data == NULL);
-    L2J(L)->vmevent_cb = NULL;
-    L2J(L)->vmevent_data = NULL;
+    G(L)->vmevent_cb = NULL;
+    G(L)->vmevent_data = NULL;
   }
   return 1;
 }
 
 LUA_API luaJIT_vmevent_callback luaJIT_vmevent_gethook(lua_State *L, void **data)
 {
-  *data = L2J(L)->vmevent_data;
-  return L2J(L)->vmevent_cb;
+  *data = G(L)->vmevent_data;
+  return G(L)->vmevent_cb;
 }
 

--- a/src/lj_vmevent.h
+++ b/src/lj_vmevent.h
@@ -49,8 +49,8 @@ typedef enum {
     } \
   }
 #define lj_vmevent_send_(L, ev, args, post) \
-  if(L2J(L)->vmevent_cb != NULL){\
-    L2J(L)->vmevent_cb(L2J(L)->vmevent_data, L, VMEVENT_##ev, 0);\
+  if(G(L)->vmevent_cb != NULL){\
+    G(L)->vmevent_cb(G(L)->vmevent_data, L, VMEVENT_##ev, 0);\
   }\
   if (G(L)->vmevmask & VMEVENT_MASK(LJ_VMEVENT_##ev)) { \
     ptrdiff_t argbase = lj_vmevent_prepare(L, LJ_VMEVENT_##ev); \
@@ -62,29 +62,29 @@ typedef enum {
   }
 
 #define lj_vmevent_callback(L, ev, args) \
-  if(L2J(L)->vmevent_cb != NULL){\
-    L2J(L)->vmevent_cb(L2J(L)->vmevent_data, L, ev, args);\
+  if(G(L)->vmevent_cb != NULL){\
+    G(L)->vmevent_cb(G(L)->vmevent_data, L, ev, args);\
   }
 
 /* Special version where the event data struct declared in the macro. Avoids
-** the need for a L2J(L)->vmevent_cb != NULL check outside the macro and cleanly disables
+** the need for a G(L)->vmevent_cb != NULL check outside the macro and cleanly disables
 ** when VM events are compiled out.
 */
 #define lj_vmevent_callback_(L, ev, build_eventdata) \
-  if(L2J(L)->vmevent_cb != NULL){\
+  if(G(L)->vmevent_cb != NULL){\
     build_eventdata \
-    L2J(L)->vmevent_cb(L2J(L)->vmevent_data, L, ev, &eventdata);\
+    G(L)->vmevent_cb(G(L)->vmevent_data, L, ev, &eventdata);\
   }
 
 #define lj_vmevent_send2(L, ev, callbackarg, args) \
-  if(L2J(L)->vmevent_cb != NULL){\
-    L2J(L)->vmevent_cb(L2J(L)->vmevent_data, L, VMEVENT_##ev, callbackarg);\
+  if(G(L)->vmevent_cb != NULL){\
+    G(L)->vmevent_cb(G(L)->vmevent_data, L, VMEVENT_##ev, callbackarg);\
   }\
   lj_vmevent_send(L, ev, args) 
 
 #define lj_vmevent_send_trace(L, subevent, callbackarg, args) \
-  if(L2J(L)->vmevent_cb != NULL){\
-    L2J(L)->vmevent_cb(L2J(L)->vmevent_data, L, VMEVENT_TRACE_##subevent, callbackarg);\
+  if(G(L)->vmevent_cb != NULL){\
+    G(L)->vmevent_cb(G(L)->vmevent_data, L, VMEVENT_TRACE_##subevent, callbackarg);\
   }\
   lj_vmevent_send(L, TRACE, args)
 


### PR DESCRIPTION
The callback pointer and user data are now stored in the global_state instead of the jit_state that gets removed in no jit builds. All the trace related events handlers are also now disabled in the VM event printer for no jit builds.