### PR TITLE
Add the main set messages/events for the JITLog

### DIFF
--- a/src/jitlog/messages.lua
+++ b/src/jitlog/messages.lua
@@ -1,3 +1,31 @@
+--[[
+  The built-in numeric types are u8/s8, u16/s16, u32/s32, u64/s64 unsigned and signed respectively.
+  Field types that are declared with just a number with no 's' or 'u' prefix are considered unsigned 
+  bit fields with a max size of 32 bits.
+  Array fields are specified as a element type followed by open and close brackets with the name of 
+  the array's length field in-between them like this i32[elementcount_field].
+
+Special field types
+  ptr: A pointer field that is always stored as a 64 bit value on both 32 bit and 64 bit builds.
+  GCRef: A pointer to a GC object passed in to the log function as a GCRef struct value. This type is
+         32 bits wide on both 32 bit and 64 bit (non GC64) builds it grows to 64 bits for GC64 builds.
+  GCRefPtr: The same as GCRef except the value is passed in as a pointer instead of a GCRef struct
+            in the writer.
+  bool: A boolean stored as a bit field with a bit width of one. It should be turned back into a native 
+        boolean value by the reader.
+  timestamp: An implicit 64 bit time stamp generated when the message is written. By default this is 
+             the value returned from rdtsc.
+  string: An array field that has extra logic in both the writer and reader side to work as a string.
+          If no length field is specified one is implicitly generated and strlen is used to determine
+          the length on the writer side and the null terminator skipped.
+  stringlist: A list of strings joined together into an array but separated with nulls chars.
+
+Message Flags:
+  use_msgsize: If the message only has one variable length field, then omit this length field and use the
+               message size field instead minus the fixed size part of the message.
+
+]]--
+
 local msgs = {
   {
     name = "header",

--- a/src/jitlog/messages.lua
+++ b/src/jitlog/messages.lua
@@ -64,6 +64,14 @@ local msgs = {
     "traceid : u16",
     "exit : u16",
   },
+
+  {
+    name = "alltraceflush",
+    "time : timestamp",
+    "reason : u16",
+    "tracelimit : u16",
+    "mcodelimit : u32",
+  },
 }
 
 return msgs

--- a/src/jitlog/messages.lua
+++ b/src/jitlog/messages.lua
@@ -72,6 +72,15 @@ local msgs = {
     "tracelimit : u16",
     "mcodelimit : u32",
   },
+
+  {
+    name = "gcstate",
+    "time : timestamp",
+    "state : 8",
+    "prevstate : 8",
+    "totalmem : u32",
+    "strnum : u32",
+  },
 }
 
 return msgs

--- a/src/jitlog/messages.lua
+++ b/src/jitlog/messages.lua
@@ -50,6 +50,20 @@ local msgs = {
     "label : string",
     use_msgsize = "label",
   },
+
+  {
+    name = "traceexit_small",
+    "isgcexit : bool",
+    "traceid : 14",
+    "exit : 9",
+  },
+
+  {
+    name = "traceexit",
+    "isgcexit : bool",
+    "traceid : u16",
+    "exit : u16",
+  },
 }
 
 return msgs

--- a/src/jitlog/messages.lua
+++ b/src/jitlog/messages.lua
@@ -39,6 +39,7 @@ local msgs = {
     "cpumodel_length : u8",
     "cpumodel : string[cpumodel_length]",
     "os : string",
+    "starttime : timestamp",
     "ggaddress : u64",
   },
   

--- a/src/jitlog/messages.lua
+++ b/src/jitlog/messages.lua
@@ -16,9 +16,9 @@ local msgs = {
   
   {
     name = "stringmarker",
+    "time : timestamp",
     "flags : 16",
     "label : string",
-    "time : timestamp",
     use_msgsize = "label",
   },
 }

--- a/src/jitlog/reader.lua
+++ b/src/jitlog/reader.lua
@@ -282,6 +282,31 @@ local function applymixin(self, mixin)
   end
 end
 
+local msgstats_mixin = {
+  init = function(self)
+    local datatotals = table.new(255, 0)
+    for i = 0, 255 do
+      datatotals[i] = 0
+    end
+    self.datatotals = datatotals
+  
+    local msgcounts = table.new(255, 0)
+    for i = 0, 255 do
+      msgcounts[i] = 0
+    end
+    -- Map message names to an index
+    setmetatable(msgcounts, {__index = function(counts, key)
+      local index = self.msgtype[key]
+      return index and counts[index] 
+    end})
+    self.msgcounts = msgcounts
+  end,
+  aftermsg = function(self, msgtype, size, pos)
+    self.datatotals[msgtype] = self.datatotals[msgtype] + size
+    self.msgcounts[msgtype] = self.msgcounts[msgtype] + 1
+  end,
+}
+
 local builtin_mixins = {
   msgstats = msgstats_mixin,
 }

--- a/src/jitlog/reader.lua
+++ b/src/jitlog/reader.lua
@@ -65,6 +65,7 @@ function logreader:readheader(buff, buffsize, info)
   info.fixedsize = header.headersize
   info.os = header:get_os()
   info.cpumodel = header:get_cpumodel()
+  info.starttime = header.starttime
   self:log_msg("header", "LogHeader: Version %d, OS %s, CPU %s", info.version, info.os, info.cpumodel)
 
   local file_msgnames = header:get_msgnames()
@@ -150,6 +151,8 @@ end
 local function nop() end
 
 function logreader:processheader(header)
+  self.starttime = header.starttime
+
   -- Make the msgtype enum for this file
   local msgtype = {
     names = header.msgnames

--- a/src/jitlog/reader.lua
+++ b/src/jitlog/reader.lua
@@ -239,6 +239,9 @@ end
 local lib = {
   makereader = makereader,
   parsebuffer = function(buff, length)
+    if not length then
+      length = #buff
+    end
     local reader = makereader()
     assert(reader:parse_buffer(buff, length))
     return reader

--- a/src/jitlog/reader.lua
+++ b/src/jitlog/reader.lua
@@ -10,8 +10,7 @@ local msgsizes = logdef.msgsizes
 
 local base_actions = {}
 
-function base_actions:stringmarker(buff)
-  local msg = ffi.cast("MSG_stringmarker*", buff)
+function base_actions:stringmarker(msg)
   local label = msg:get_label()
   local flags = msg:get_flags()
   local time = msg.time
@@ -24,6 +23,7 @@ function base_actions:stringmarker(buff)
   }
   self.markers[#self.markers + 1] = marker
   self:log_msg("stringmarker", "StringMarker: %s %s", label, time)
+  return marker
 end
 
 local logreader = {}
@@ -150,6 +150,32 @@ end
 
 local function nop() end
 
+local function make_msghandler(msgname, base, funcs)
+  msgname = msgname.."*"
+  -- See if we can go for the simple case with no extra funcs call first
+  if not funcs or (type(funcs) == "table" and #funcs == 0) then
+    return function(self, buff, limit)
+      base(self, ffi.cast(msgname, buff), limit)
+      return
+    end
+  elseif type(funcs) == "function" or #funcs == 1 then
+    local f = (type(funcs) == "function" and funcs) or funcs[1]
+    return function(self, buff, limit)
+      local msg = ffi.cast(msgname, buff)
+      f(self, msg, base(self, msg, limit))
+      return
+    end
+  else
+    return function(self, buff, limit)
+      local msg = ffi.cast(msgname, buff)
+      local ret1, ret2 = base(msg, limit)
+      for _, f in ipairs(funcs) do
+        f(self, msg, ret1, ret2)
+      end
+    end
+  end
+end
+
 function logreader:processheader(header)
   self.starttime = header.starttime
 
@@ -186,18 +212,20 @@ function logreader:processheader(header)
       assert(-size < 4*1024)
     else
       -- Msg size dispatch table is designed to be only 8 bits per slot
-      assert(size < 255)
+      assert(size < 255 and size >= 4)
     end
   end
 
-  local actionfuncs = self.actions or base_actions
-
   -- Map message functions associated with a message name to this files message types
-  local dispatch = table.new(255, 0) 
+  local dispatch = table.new(255, 0)
+  for i = 0, 254 do
+    dispatch[i] = nop
+  end
+  local base_actions = self.base_actions or base_actions
   for i, name in ipairs(header.msgnames) do
-    local action = actionfuncs[name]
-    if action then
-      dispatch[i-1] = action
+    local action = self.actions[name]
+    if base_actions[name] or action then
+      dispatch[i-1] = make_msghandler("MSG_"..name, base_actions[name], action)
     end
   end
   self.dispatch = dispatch
@@ -226,9 +254,42 @@ end
 
 local mt = {__index = logreader}
 
-local function makereader()
+local function applymixin(self, mixin)
+  if mixin.init then
+    mixin.init(self)
+  end
+  if mixin.actions then
+    for name, action in pairs(mixin.actions) do
+      local list = self.actions[name] 
+      if not list then
+        self.actions[name] = {action}
+      else
+        list[#list + 1] = action
+      end
+    end
+  end
+  if mixin.aftermsg then
+    if not self.allmsgcb then
+      self.allmsgcb = mixin.aftermsg
+    else
+      local callback1 = self.allmsgcb
+      local callback2 = mixin.aftermsg
+      self.allmsgcb = function(self, msgtype, size, pos)
+        callback1(self, msgtype, size, pos)
+        callback2(self, msgtype, size, pos)
+      end
+    end
+  end
+end
+
+local builtin_mixins = {
+  msgstats = msgstats_mixin,
+}
+
+local function makereader(mixins)
   local t = {
     eventid = 0,
+    actions = {},
     markers = {},
     verbose = false,
     logfilter = {
@@ -236,6 +297,11 @@ local function makereader()
       --stringmarker = true,
     }
   }
+  if mixins then
+    for _, mixin in ipairs(mixins) do
+      applymixin(t, mixin)
+    end
+  end
   return setmetatable(t, mt)
 end
 
@@ -254,6 +320,9 @@ local lib = {
     reader:parsefile(filepath)
     return reader
   end,
+  base_actions = base_actions,
+  make_msgparser = make_msgparser,
+  mixins = builtin_mixins,
 }
 
 return lib

--- a/src/jitlog/reader.lua
+++ b/src/jitlog/reader.lua
@@ -26,6 +26,23 @@ function base_actions:stringmarker(msg)
   return marker
 end
 
+function base_actions:traceexit(msg)
+  local id = msg:get_traceid()
+  local exit = msg:get_exit()
+  local gcexit = msg:get_isgcexit()
+  self.exits = self.exits + 1
+  if gcexit then
+    assert(self.gcstate == "atomic" or self.gcstate == "finalize")
+    self.gcexits = self.gcexits + 1
+    self:log_msg("traceexit", "TraceExit(%d): %d GC Triggered", id, exit)
+  else
+    self:log_msg("traceexit", "TraceExit(%d): %d", id, exit)
+  end
+  return id, exit, gcexit
+end
+-- Reuse handler for compact trace exit messages since they both have the same field names but traceid and exit are smaller
+base_actions.traceexit_small = base_actions.traceexit
+
 local logreader = {}
 
 function logreader:log(fmt, ...)
@@ -316,6 +333,8 @@ local function makereader(mixins)
     eventid = 0,
     actions = {},
     markers = {},
+    exits = 0,
+    gcexits = 0, -- number of trace exits force triggered by the GC being in the 'atomic' or 'finalize' states
     verbose = false,
     logfilter = {
       --header = true,

--- a/src/jitlog/test.lua
+++ b/src/jitlog/test.lua
@@ -226,6 +226,16 @@ function tests.tracexits()
   assert(result.msgcounts.traceexit_small == result.exits)
 end
 
+function tests.userflush()
+  jitlog.start()
+  jit.flush()
+  local result = parselog(jitlog.savetostring())
+  assert(#result.flushes == 1)
+  assert(result.msgcounts.alltraceflush == 1)
+  assert(result.flushes[1].reason == "user_requested")
+  assert(result.flushes[1].time > 0)
+end
+
 end
 
 local failed = false

--- a/src/jitlog/test.lua
+++ b/src/jitlog/test.lua
@@ -190,6 +190,20 @@ function tests.reset()
   parselog(log2)
 end
 
+function tests.stringmarker()
+  jitlog.start()
+  jitlog.addmarker("marker1")
+  jitlog.addmarker("marker2", 0xbeef)
+  local result = parselog(jitlog.savetostring())
+  assert(#result.markers == 2)
+  assert(result.markers[1].label == "marker1")
+  assert(result.markers[2].label == "marker2")
+  assert(result.markers[1].eventid < result.markers[2].eventid)
+  assert(result.markers[1].time < result.markers[2].time)
+  assert(result.markers[1].flags == 0)
+  assert(result.markers[2].flags == 0xbeef)
+end
+
 local failed = false
 
 for name, test in pairs(tests) do

--- a/src/jitlog/test.lua
+++ b/src/jitlog/test.lua
@@ -1,4 +1,5 @@
 local ffi = require("ffi")
+local hasjit = pcall(require, "jit.opt")
 local format = string.format
 local reader_def = require("jitlog.reader_def")
 GC64 = reader_def.GC64
@@ -207,6 +208,24 @@ function tests.stringmarker()
   assert(result.markers[1].time < result.markers[2].time)
   assert(result.markers[1].flags == 0)
   assert(result.markers[2].flags == 0xbeef)
+end
+
+if hasjit then
+
+function tests.tracexits()
+  jitlog.start()
+  local a = 0 
+  for i = 1, 200 do
+    if i <= 100 then
+      a = a + 1
+    end
+  end
+  assert(a == 100)
+  local result = parselog(jitlog.savetostring())
+  assert(result.exits > 4)
+  assert(result.msgcounts.traceexit_small == result.exits)
+end
+
 end
 
 local failed = false

--- a/src/jitlog/test.lua
+++ b/src/jitlog/test.lua
@@ -238,6 +238,27 @@ end
 
 end
 
+function tests.gcstate()
+  jitlog.start()
+  collectgarbage("collect")
+  local t = {}
+  for i=1, 10000 do
+    t[i] = {1, 2, true, false}
+  end
+  assert(#t == 10000)
+  local result = parselog(jitlog.savetostring())
+  assert(result.gccount > 0)
+  assert(result.gcstatecount > 4)
+  assert(result.gcstatecount == result.msgcounts.gcstate)
+  assert(result.peakmem > 0)
+  assert(result.peakstrnum > 0)
+  if hasjit then
+    assert(result.exits > 0)
+    assert(result.gcexits > 0)
+    assert(result.gcexits <= result.exits)
+  end
+end
+
 local failed = false
 
 for name, test in pairs(tests) do

--- a/src/jitlog/test.lua
+++ b/src/jitlog/test.lua
@@ -186,8 +186,9 @@ function tests.reset()
   local log2 = jitlog.savetostring()
   assert(#log1 > #log2)
 
-  parselog(log1)
-  parselog(log2)
+  local result1 = parselog(log1)
+  local result2 = parselog(log2)
+  assert(result1.starttime < result2.starttime)
 end
 
 function tests.stringmarker()

--- a/src/jitlog/test.lua
+++ b/src/jitlog/test.lua
@@ -147,15 +147,18 @@ local function checkheader(header)
   assert(header.version > 0)
 end
 
+
+
+local testmixins = {
+  readerlib.mixins.msgstats,
+}
+
 local function parselog(log, verbose)
-  local result
+  local result = readerlib.makereader(testmixins)
   if verbose then
-    result = readerlib.makereader()
     result.verbose = true
-    assert(result:parse_buffer(log, #log))
-  else
-    result = readerlib.parsebuffer(log)
   end
+  assert(result:parse_buffer(log, #log))
   checkheader(result.header)
   return result
 end
@@ -196,6 +199,7 @@ function tests.stringmarker()
   jitlog.addmarker("marker1")
   jitlog.addmarker("marker2", 0xbeef)
   local result = parselog(jitlog.savetostring())
+  assert(result.msgcounts.stringmarker == 2)
   assert(#result.markers == 2)
   assert(result.markers[1].label == "marker1")
   assert(result.markers[2].label == "marker2")

--- a/src/lj_gc.c
+++ b/src/lj_gc.c
@@ -727,10 +727,14 @@ int LJ_FASTCALL lj_gc_step_jit(global_State *g, MSize steps)
   lua_State *L = gco2th(gcref(g->cur_L));
   L->base = tvref(G(L)->jit_base);
   L->top = curr_topL(L);
-  while (steps-- > 0 && lj_gc_step(L) == 0)
-    ;
-  /* Return 1 to force a trace exit. */
-  return (G(L)->gc.state == GCSatomic || G(L)->gc.state == GCSfinalize);
+  while (steps-- > 0 && lj_gc_step(L) == 0) {}
+  if ((G(L)->gc.state == GCSatomic || G(L)->gc.state == GCSfinalize)) {
+    G(L)->gc.gcexit = 1;
+    /* Return 1 to force a trace exit. */
+    return 1;
+  } else {
+    return 0;
+  }
 }
 #endif
 

--- a/src/lj_jitlog.c
+++ b/src/lj_jitlog.c
@@ -51,6 +51,13 @@ static void jitlog_traceflush(JITLogState *context, FlushReason reason)
 }
 
 #endif
+
+static void jitlog_gcstate(JITLogState *context, int newstate)
+{
+  global_State *g = context->g;
+  log_gcstate(g, newstate, g->gc.state, g->gc.total, g->strnum);
+}
+
 static void free_context(JITLogState *context);
 
 static void jitlog_callback(void *contextptr, lua_State *L, int eventid, void *eventdata)
@@ -67,6 +74,9 @@ static void jitlog_callback(void *contextptr, lua_State *L, int eventid, void *e
       jitlog_traceflush(context, (FlushReason)(uintptr_t)eventdata);
       break;
 #endif
+    case VMEVENT_GC_STATECHANGE:
+      jitlog_gcstate(context, (int)(uintptr_t)eventdata);
+      break;
     case VMEVENT_DETACH:
       free_context(context);
       break;

--- a/src/lj_jitlog.c
+++ b/src/lj_jitlog.c
@@ -44,6 +44,12 @@ static void jitlog_exit(JITLogState *context, VMEventData_TExit *exitState)
   }
 }
 
+static void jitlog_traceflush(JITLogState *context, FlushReason reason)
+{
+  jit_State *J = G2J(context->g);
+  log_alltraceflush(context->g, reason, J->param[JIT_P_maxtrace], J->param[JIT_P_maxmcode] << 10);
+}
+
 #endif
 static void free_context(JITLogState *context);
 
@@ -56,6 +62,9 @@ static void jitlog_callback(void *contextptr, lua_State *L, int eventid, void *e
 #if LJ_HASJIT
     case VMEVENT_TRACE_EXIT:
       jitlog_exit(context, (VMEventData_TExit*)eventdata);
+      break;
+    case VMEVENT_TRACE_FLUSH:
+      jitlog_traceflush(context, (FlushReason)(uintptr_t)eventdata);
       break;
 #endif
     case VMEVENT_DETACH:

--- a/src/lj_jitlog.c
+++ b/src/lj_jitlog.c
@@ -248,11 +248,28 @@ static int jlib_save(lua_State *L)
   return 0;
 }
 
+static int jlib_savetostring(lua_State *L)
+{
+  JITLogState *context = jlib_getstate(L);
+  lua_pushlstring(L, sbufB(&context->eventbuf), sbuflen(&context->eventbuf));
+  return 1;
+}
+
+static int jlib_getsize(lua_State *L)
+{
+  JITLogState *context = jlib_getstate(L);
+  SBuf *sb = &context->eventbuf;
+  lua_pushnumber(L, sbuflen(sb));
+  return 1;
+}
+
 static const luaL_Reg jitlog_lib[] = {
   {"start", jlib_start},
   {"shutdown", jlib_shutdown},
   {"reset", jlib_reset},
   {"save", jlib_save},
+  {"savetostring", jlib_savetostring},
+  {"getsize", jlib_getsize},
   {"addmarker", jlib_addmarker},
   {NULL, NULL},
 };

--- a/src/lj_obj.h
+++ b/src/lj_obj.h
@@ -577,7 +577,7 @@ typedef struct GCState {
   uint8_t currentwhite;	/* Current white color. */
   uint8_t state;	/* GC state. */
   uint8_t nocdatafin;	/* No cdata finalizer called. */
-  uint8_t unused2;
+  uint8_t gcexit;
   MSize sweepstr;	/* Sweep position in string table. */
   GCRef root;		/* List of all collectable objects. */
   MRef sweep;		/* Sweep position in root list. */

--- a/src/lj_trace.c
+++ b/src/lj_trace.c
@@ -865,6 +865,8 @@ int LJ_FASTCALL lj_trace_exit(jit_State *J, void *exptr)
 
   lj_vmevent_callback_(L, VMEVENT_TRACE_EXIT,
     VMEventData_TExit eventdata;
+    eventdata.gcexit = G(L)->gc.gcexit;
+    G(L)->gc.gcexit = 0;
     eventdata.gprs = &ex->gpr;
     eventdata.gprs_size = sizeof(ex->gpr);
     eventdata.fprs = &ex->fpr;

--- a/src/vmevent.h
+++ b/src/vmevent.h
@@ -42,6 +42,7 @@ typedef struct VMEventData_TExit {
   void *gprs;
   void *fprs;
   void *spill;
+  char gcexit;
 } VMEventData_TExit;
 
 typedef struct VMEventData_ProtoBL {


### PR DESCRIPTION
Add recording of some of the interesting JIT events to the JITLog these events include:
- Trace exits which is just the trace id, exit number and if it was triggered by the GC.
- Full trace flushes where all the traces are thrown away this can be trigged from hitting limits like total machine code memory used, total traces created or explicitly by the user and some very special cases like replacing the metatable of a built-in type.
- Function byte code getting JIT blacklisting where the bytecode is modified to stop doing hot counting and triggering traces.
- When the GC state changes that also includes the current GC heapsize and total number of strings.

The jitlog Lua module also gained some new APIs:
- jitlog.savetostring() Saves the raw binary log to a string(Lua strings can just be blobs of memory) which simplifies the tests.
- jitlog.getsize() Returns the current size of the jitlog.
